### PR TITLE
Use Perl grep

### DIFF
--- a/scripts/get_funcs.pl
+++ b/scripts/get_funcs.pl
@@ -264,9 +264,14 @@ sub read_file() {
 	  
 	  print DOCS "Other flags    : $infos2[7]\n";
 
-          $shortname = lc(substr($infos0[0], 3));
-          $set_params = `grep "xc_${shortname}_set_params(xc_func_type" $srcdir/$file`;
-	  chomp $set_params;
+	  open(IN, "<$srcdir/$file");
+	  chomp(my @lines = <IN>);
+	  close(IN);
+
+	  $shortname = lc(substr($infos0[0], 3));
+	  @lines = grep {/xc_${shortname}_set_params\(xc_func_type/} @lines;
+	  $set_params = shift @lines;
+
 	  if($set_params ne "") {
 	      if($set_params !~ /void/) {
 		  $set_params = "void $set_params";


### PR DESCRIPTION
This is a part of Psi4 porting to Windows (https://github.com/psi4/psi4/issues/933)

- [x] Use Perl `grep` instead of calling system `grep`.

This has already been merged to the upstream (https://gitlab.com/libxc/libxc/merge_requests/104/)