### PR TITLE
Port to Windows

### DIFF
--- a/src/functionals.c
+++ b/src/functionals.c
@@ -10,7 +10,12 @@
 #include "xc.h"
 #include "funcs_key.c"
 #include <string.h>
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#else
 #include <strings.h>
+#endif
 
 extern xc_func_info_type 
   *xc_lda_known_funct[], 
@@ -48,7 +53,7 @@ int xc_functional_get_number(const char *name)
 
 
 /*------------------------------------------------------*/
-char *xc_functional_get_name(const int number)
+char *xc_functional_get_name(int number)
 {
   int ii;
 

--- a/src/gga.c
+++ b/src/gga.c
@@ -119,7 +119,7 @@ void xc_gga(const xc_func_type *func, int np, const double *rho, const double *s
 
 /* specializations */
 /* returns only energy */
-inline void 
+void
 xc_gga_exc(const xc_func_type *p, int np, const double *rho, const double *sigma, 
 	    double *zk)
 {
@@ -127,7 +127,7 @@ xc_gga_exc(const xc_func_type *p, int np, const double *rho, const double *sigma
 }
 
 /* returns only potential */
-inline void 
+void
 xc_gga_vxc(const xc_func_type *p, int np, const double *rho, const double *sigma,
 	    double *vrho, double *vsigma)
 {
@@ -135,7 +135,7 @@ xc_gga_vxc(const xc_func_type *p, int np, const double *rho, const double *sigma
 }
 
 /* returns both energy and potential (the most common call usually) */
-inline void 
+void
 xc_gga_exc_vxc(const xc_func_type *p, int np, const double *rho, const double *sigma,
 		double *zk, double *vrho, double *vsigma)
 {
@@ -143,7 +143,7 @@ xc_gga_exc_vxc(const xc_func_type *p, int np, const double *rho, const double *s
 }
 
 /* returns second derivatives */
-inline void 
+void
 xc_gga_fxc(const xc_func_type *p, int np, const double *rho, const double *sigma,
 	    double *v2rho2, double *v2rhosigma, double *v2sigma2)
 {
@@ -151,7 +151,7 @@ xc_gga_fxc(const xc_func_type *p, int np, const double *rho, const double *sigma
 }
 
 /* returns third derivatives */
-inline void 
+void
 xc_gga_kxc(const xc_func_type *p, int np, const double *rho, const double *sigma,
 	    double *v3rho3, double *v3rho2sigma, double *v3rhosigma2, double *v3sigma3)
 {

--- a/src/lda.c
+++ b/src/lda.c
@@ -64,31 +64,31 @@ xc_lda(const xc_func_type *func, int np, const double *rho,
 
 
 /* specializations */
-inline void 
+void
 xc_lda_exc(const xc_func_type *p, int np, const double *rho, double *zk)
 {
   xc_lda(p, np, rho, zk, NULL, NULL, NULL);
 }
 
-inline void 
+void
 xc_lda_exc_vxc(const xc_func_type *p, int np, const double *rho, double *zk, double *vrho)
 {
   xc_lda(p, np, rho, zk, vrho, NULL, NULL);
 }
 
-inline void 
+void
 xc_lda_vxc(const xc_func_type *p, int np, const double *rho, double *vrho)
 {
   xc_lda(p, np, rho, NULL, vrho, NULL, NULL);
 }
 
-inline void 
+void
 xc_lda_fxc(const xc_func_type *p, int np, const double *rho, double *v2rho2)
 {
   xc_lda(p, np, rho, NULL, NULL, v2rho2, NULL);
 }
 
-inline void 
+void
 xc_lda_kxc(const xc_func_type *p, int np, const double *rho, double *v3rho3)
 {
   xc_lda(p, np, rho, NULL, NULL, NULL, v3rho3);

--- a/src/mgga.c
+++ b/src/mgga.c
@@ -89,7 +89,7 @@ xc_mgga(const xc_func_type *func, int np,
 }
 
 /* specializations */
-inline void 
+void
 xc_mgga_exc(const xc_func_type *p, int np, 
 	     const double *rho, const double *sigma, const double *lapl, const double *tau,
 	     double *zk)
@@ -98,7 +98,7 @@ xc_mgga_exc(const xc_func_type *p, int np,
 	   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
-inline void 
+void
 xc_mgga_exc_vxc(const xc_func_type *p, int np,
 		 const double *rho, const double *sigma, const double *lapl, const double *tau,
 		 double *zk, double *vrho, double *vsigma, double *vlapl, double *vtau)
@@ -107,7 +107,7 @@ xc_mgga_exc_vxc(const xc_func_type *p, int np,
 	   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
-inline void 
+void
 xc_mgga_vxc(const xc_func_type *p, int np,
 	     const double *rho, const double *sigma, const double *lapl, const double *tau,
 	     double *vrho, double *vsigma, double *vlapl, double *vtau)
@@ -116,7 +116,7 @@ xc_mgga_vxc(const xc_func_type *p, int np,
 	   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
-inline void 
+void
 xc_mgga_fxc(const xc_func_type *p, int np,
 	     const double *rho, const double *sigma, const double *lapl, const double *tau,
 	     double *v2rho2, double *v2sigma2, double *v2lapl2, double *v2tau2,

--- a/src/util.h
+++ b/src/util.h
@@ -55,17 +55,6 @@
 #define POW_7_3(x) pow((x), 7.0/3.0)
 #endif
 
-#ifdef _MSC_VER
-#define strcasecmp  _stricmp
-#define strncasecmp _strnicmp
-
-double asinh (double x);
-float  asinhf(float  x);
-double erf(double);
-double erfc(double);
-#endif
-
-
 #define M_SQRTPI        1.772453850905516027298167483341145182798L
 #define M_SQRT3         1.732050807568877293527446341505872366943L
 #define M_CBRT2         1.259921049894873164767210607278228350570L
@@ -120,7 +109,7 @@ double xc_bessel_K0(const double x);
 double xc_bessel_K1_scaled(const double x);
 double xc_bessel_K1(const double x);
 
-double xc_expint_e1_impl(const double x, const int scale);
+double xc_expint_e1_impl(double x, const int scale);
 static inline double expint_e1(const double x)         { return  xc_expint_e1_impl( x, 0); }
 static inline double expint_e1_scaled(const double x)  { return  xc_expint_e1_impl( x, 1); }
 static inline double expint_Ei(const double x)         { return -xc_expint_e1_impl(-x, 0); }


### PR DESCRIPTION
- [x] Match function signatures (MSVC is more picky)
- [x] Add portability definitions for MSVC

This is a part of Psi4 porting to Windows (https://github.com/psi4/psi4/issues/933)

This has already been merged to the upstream (https://gitlab.com/libxc/libxc/merge_requests/106)