### PR TITLE
Add configuration for CI on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+clone_depth: 1
+platform: x64
+
+image:
+  - Visual Studio 2015
+  - Visual Studio 2017
+
+configuration:
+  - Release
+
+before_build:
+  - mkdir libxc_build && cd libxc_build
+  - cmake -A %PLATFORM%
+          -DCMAKE_BUILD_TYPE=%CONFIGURATION%
+          -DENABLE_XHOST=OFF
+          -DCMAKE_C_FLAGS="/wd4101 /wd4996"
+          ..
+
+build_script:
+  - cmake --build .
+          --config %CONFIGURATION%
+
+test_script:
+  - ctest --build-config %CONFIGURATION%
+          --output-on-failure


### PR DESCRIPTION
- [x] Add Appveyor configuration to compile and tests on Windows (https://ci.appveyor.com/project/raimis/libxc-udj4h).

Appveyor has to be activated on the repository to work (https://www.appveyor.com/docs/).

This is a part of Psi4 porting to Windows (https://github.com/psi4/psi4/issues/933)

This has already been merged to the upstream (https://gitlab.com/libxc/libxc/merge_requests/107)